### PR TITLE
Fixed support for older versions of Nuxt

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -29,10 +29,11 @@ module.exports = function (moduleOptions) {
     '.eslintrc.js'
   ]
 
+  this.options.watch = this.options.watch || []
   this.options.watch.push(
     ...filesToWatch.map(file => resolve(this.options.rootDir, file))
   )
-
+  
   this.extendBuild((config, { isDev, isClient }) => {
     if (isDev && isClient) {
       const EslintPlugin = require('eslint-webpack-plugin')


### PR DESCRIPTION
If `nuxt.config.js` doesn't contain a `watch` property, Nuxt v1.4.2 fails to render a page with a `TypeError: Cannot read property 'push' of undefined` error.

This PR adds an empty `watch` array to the `options` as a fallback to fix the issue.

Tested on Nuxt v1.4.2 and v2.14.6